### PR TITLE
fix: show placeholder image if product image is null.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,43 +1,43 @@
-aiosql==3.3.1
-alembic==1.7.6
-anyio==3.5.0
-asgiref==3.5.0
-asyncpg==0.25.0
-bcrypt==3.2.0
-certifi==2021.10.8
-cffi==1.15.0
-charset-normalizer==2.0.11
-click==8.0.3
-colorama==0.4.4; platform_system == "Windows"
-colorama==0.4.4; sys_platform == "win32"
-contextlib2==21.6.0
-databases==0.5.5
-dnspython==2.2.0
-email-validator==1.1.3
-fastapi==0.73.0
-greenlet==1.1.2; python_version >= "3" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
-gunicorn==20.1.0
-h11==0.12.0
-idna==3.3
-loguru==0.6.0
-mako==1.1.6
-markupsafe==2.0.1
-passlib==1.7.4
-psycopg2-binary==2.9.3
-pycparser==2.21
-pydantic==1.9.0
-pyjwt==2.3.0
-pypika==0.48.8
-python-dotenv==0.19.2
-python-slugify==5.0.2
-requests==2.28.0
-six==1.16.0
-sniffio==1.2.0
-sqlalchemy==1.4.31
-starlette==0.17.1
-text-unidecode==1.3
-typing-extensions==3.10.0.2
-unidecode==1.3.2
-urllib3==1.26.9
-uvicorn==0.17.4
-win32-setctime==1.1.0; sys_platform == "win32"
+aiosql==3.3.1 ; python_full_version == "3.9.13"
+alembic==1.7.6 ; python_full_version == "3.9.13"
+anyio==3.5.0 ; python_full_version == "3.9.13"
+asgiref==3.5.0 ; python_full_version == "3.9.13"
+asyncpg==0.25.0 ; python_full_version == "3.9.13"
+bcrypt==3.2.0 ; python_full_version == "3.9.13"
+certifi==2021.10.8 ; python_full_version == "3.9.13"
+cffi==1.15.0 ; python_full_version == "3.9.13"
+charset-normalizer==2.0.11 ; python_full_version == "3.9.13"
+click==8.0.3 ; python_full_version == "3.9.13"
+colorama==0.4.4 ; sys_platform == "win32" and python_full_version == "3.9.13" or platform_system == "Windows" and python_full_version == "3.9.13"
+contextlib2==21.6.0 ; python_full_version == "3.9.13"
+databases==0.5.5 ; python_full_version == "3.9.13"
+dnspython==2.2.0 ; python_full_version == "3.9.13"
+email-validator==1.1.3 ; python_full_version == "3.9.13"
+fastapi==0.73.0 ; python_full_version == "3.9.13"
+greenlet==1.1.2 ; python_full_version == "3.9.13" and (platform_machine == "aarch64" or platform_machine == "ppc64le" or platform_machine == "x86_64" or platform_machine == "amd64" or platform_machine == "AMD64" or platform_machine == "win32" or platform_machine == "WIN32")
+gunicorn==20.1.0 ; python_full_version == "3.9.13"
+h11==0.12.0 ; python_full_version == "3.9.13"
+idna==3.3 ; python_full_version == "3.9.13"
+loguru==0.6.0 ; python_full_version == "3.9.13"
+mako==1.1.6 ; python_full_version == "3.9.13"
+markupsafe==2.0.1 ; python_full_version == "3.9.13"
+passlib[bcrypt]==1.7.4 ; python_full_version == "3.9.13"
+psycopg2-binary==2.9.3 ; python_full_version == "3.9.13"
+pycparser==2.21 ; python_full_version == "3.9.13"
+pydantic==1.9.0 ; python_full_version == "3.9.13"
+pydantic[dotenv,email]==1.9.0 ; python_full_version == "3.9.13"
+pyjwt==2.3.0 ; python_full_version == "3.9.13"
+pypika==0.48.8 ; python_full_version == "3.9.13"
+python-dotenv==0.19.2 ; python_full_version == "3.9.13"
+python-slugify==5.0.2 ; python_full_version == "3.9.13"
+requests==2.28.0 ; python_full_version == "3.9.13"
+six==1.16.0 ; python_full_version == "3.9.13"
+sniffio==1.2.0 ; python_full_version == "3.9.13"
+sqlalchemy==1.4.31 ; python_full_version == "3.9.13"
+starlette==0.17.1 ; python_full_version == "3.9.13"
+text-unidecode==1.3 ; python_full_version == "3.9.13"
+typing-extensions==3.10.0.2 ; python_full_version == "3.9.13"
+unidecode==1.3.2 ; python_full_version == "3.9.13"
+urllib3==1.26.9 ; python_full_version == "3.9.13"
+uvicorn==0.17.4 ; python_full_version == "3.9.13"
+win32-setctime==1.1.0 ; sys_platform == "win32" and python_full_version == "3.9.13"

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image || '/placeholder.png'}
+                src={this.props.item.image || "/placeholder.png"}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
fixes #2

# Description

We now show the placeholder image in the case of a null product image.

![image](https://user-images.githubusercontent.com/26801157/194357587-2ee5cfa0-5a35-4acf-99a6-135c61ec0365.png)

![image](https://user-images.githubusercontent.com/26801157/194354402-0b52d311-ccb9-432e-9083-b3dcf650d16c.png)

